### PR TITLE
Fix invalid intermediate certificate due to letsencrypt changes

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -20,7 +20,7 @@ echo "Started python SimpleHTTPServer with pid $pid"
 export SSL_CERT_FILE=cacert.pem
 python acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/signed.crt
 echo "Downloading intermediate certificate..."
-wget --no-verbose -O - https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem > letsencrypt/intermediate.pem
+wget --no-verbose -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > letsencrypt/intermediate.pem
 cat letsencrypt/signed.crt letsencrypt/intermediate.pem > letsencrypt/chained.pem
 
 echo "Stopping stunnel and setting new stunnel certificates..."


### PR DESCRIPTION
See https://community.letsencrypt.org/t/upcoming-intermediate-changes/13106/3
All certificates are now signed by the X3 intermediate instead of X1.