### PR TITLE
Add support for IPv6-only domains

### DIFF
--- a/HTTPServer.py
+++ b/HTTPServer.py
@@ -1,12 +1,21 @@
 import socket
 from BaseHTTPServer import HTTPServer
 from SimpleHTTPServer import SimpleHTTPRequestHandler
+from threading import Thread
 
 class HTTPServerV6(HTTPServer):
   address_family = socket.AF_INET6
 
 def main():
+  Thread(target=servev4).start()
+  servev6()
+  
+def servev6():
   server = HTTPServerV6(('::', 80), SimpleHTTPRequestHandler)
+  server.serve_forever()
+  
+def servev4():
+  server = HTTPServer(('0.0.0.0', 80), SimpleHTTPRequestHandler)
   server.serve_forever()
 
 if __name__ == '__main__':

--- a/HTTPServerV6.py
+++ b/HTTPServerV6.py
@@ -1,0 +1,13 @@
+import socket
+from BaseHTTPServer import HTTPServer
+from SimpleHTTPServer import SimpleHTTPRequestHandler
+
+class HTTPServerV6(HTTPServer):
+  address_family = socket.AF_INET6
+
+def main():
+  server = HTTPServerV6(('::', 80), SimpleHTTPRequestHandler)
+  server.serve_forever()
+
+if __name__ == '__main__':
+  main()

--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -12,10 +12,10 @@ echo "Stopping Qthttpd hogging port 80.."
 
 mkdir -p tmp-webroot/.well-known/acme-challenge
 cd tmp-webroot
-python -m SimpleHTTPServer 80 &
+python ../HTTPServerV6.py &
 pid=$!
 cd ..
-echo "Started python SimpleHTTPServer with pid $pid"
+echo "Started python HTTP server with pid $pid"
 
 export SSL_CERT_FILE=cacert.pem
 python acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/signed.crt

--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -12,7 +12,7 @@ echo "Stopping Qthttpd hogging port 80.."
 
 mkdir -p tmp-webroot/.well-known/acme-challenge
 cd tmp-webroot
-python ../HTTPServerV6.py &
+python ../HTTPServer.py &
 pid=$!
 cd ..
 echo "Started python HTTP server with pid $pid"


### PR DESCRIPTION
This solves the 'ValueError' issue when verifying domains with IPv6-only DNS records.