### PR TITLE
Fix if connection to Letsencrypt-server fails.

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -o errexit
 
 # do nothing if certificate is valid for more than 30 days (30*24*60*60)
 echo "Checking whether to renew certificate on $(date -R)"
@@ -31,9 +31,8 @@ cd ..
 echo "Started python HTTP server with pid $pid"
 
 export SSL_CERT_FILE=cacert.pem
-"$PYTHON" acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/cert.pem.temp
-if [ -f letsencrypt/cert.pem.temp ] && [ -s letsencrypt/cert.pem.temp ] ; then
-mv letsencrypt/cert.pem.temp letsencrypt/signed.crt
+"$PYTHON" acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/signed.crt.tmp
+mv letsencrypt/signed.crt.tmp letsencrypt/signed.crt
 echo "Downloading intermediate certificate..."
 wget --no-verbose -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > letsencrypt/intermediate.pem
 cat letsencrypt/signed.crt letsencrypt/intermediate.pem > letsencrypt/chained.pem
@@ -45,7 +44,7 @@ cp letsencrypt/intermediate.pem /etc/stunnel/uca.pem
 
 echo "Done! Service startup and cleanup will follow now..."
 /etc/init.d/stunnel.sh start
-fi
+
 kill -9 $pid || true
 rm -rf tmp-webroot
 

--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -31,7 +31,9 @@ cd ..
 echo "Started python HTTP server with pid $pid"
 
 export SSL_CERT_FILE=cacert.pem
-"$PYTHON" acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/signed.crt
+"$PYTHON" acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/cert.pem.temp
+if [ -f letsencrypt/cert.pem.temp ] && [ -s letsencrypt/cert.pem.temp ] ; then
+mv letsencrypt/cert.pem.temp letsencrypt/signed.crt
 echo "Downloading intermediate certificate..."
 wget --no-verbose -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > letsencrypt/intermediate.pem
 cat letsencrypt/signed.crt letsencrypt/intermediate.pem > letsencrypt/chained.pem
@@ -43,7 +45,7 @@ cp letsencrypt/intermediate.pem /etc/stunnel/uca.pem
 
 echo "Done! Service startup and cleanup will follow now..."
 /etc/init.d/stunnel.sh start
-
+fi
 kill -9 $pid || true
 rm -rf tmp-webroot
 


### PR DESCRIPTION
Prevent writing empty "letsencrypt/signed.crt" when connection to Letsencrypt-server fails, leading to missing certificate.
We write into temp-file first, and if it's not empty, we write the actual file.
See: <a href="https://forum.qnapclub.de/thread/39039-howto-eigenes-zertifikat-mit-qnap-letsencrypt/?postID=222932#post222932">forum.qnapclub.de</a>.