### PR TITLE
Adding absolute path detection in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ installed. Therefore we will have to download one manually.
 
     Add this to `/etc/config/crontab`:
     ```
-    30 3 * * * cd /share/CE_CACHEDEV1_DATA/qnap-letsencrypt/ && ./renew_certificate.sh >> ./renew_certificate.log 2>&1
+    30 3 * * * /share/CE_CACHEDEV1_DATA/qnap-letsencrypt/renew_certificate.sh >> /share/CE_CACHEDEV1_DATA/qnap-letsencrypt/renew_certificate.log 2>&1
     ```
 
     Then run:


### PR DESCRIPTION
The original script create files with relative path, so what I do is to detect the path of the script and cd to there. So the commands contains relative path it will not run in wrong folder.

This might be the fastest way. The only thing I am not satisified is I have to use long abs path in crontab. However have no idea if we can avoid that under current QNAP's environment.

Note:
I just test this on my own device by execute the command under different path using absolute path pointing to renew_certificate.sh

Does not try to run from crontab but it should work. *\*finger crossed**