### PR TITLE
Replace expired letsencrypt cross-signed intermediate certificate

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -53,7 +53,7 @@ export SSL_CERT_FILE=cacert.pem
 "$PYTHON" acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/signed.crt.tmp
 mv letsencrypt/signed.crt.tmp letsencrypt/signed.crt
 echo "Downloading intermediate certificate..."
-wget --no-verbose --secure-protocol=TLSv1_2 -O - https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem > letsencrypt/intermediate.pem
+wget --no-verbose --secure-protocol=TLSv1_2 -O - https://letsencrypt.org/certs/lets-encrypt-r3.pem > letsencrypt/intermediate.pem
 cat letsencrypt/signed.crt letsencrypt/intermediate.pem > letsencrypt/chained.pem
 
 echo "Stopping stunnel and setting new stunnel certificates..."


### PR DESCRIPTION
Updating intermediate certificat, from R3 crossed signed to new R3

Fixes https://github.com/Yannik/qnap-letsencrypt/issues/106