### PR TITLE
Added check for .git folder to avoid misleading error logs

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -34,7 +34,7 @@ else
 fi
 
 echo "Renewing certificate..."
-echo "qnap-letsencrypt version: $(git rev-parse --short HEAD)"
+[ -e .git ] && echo "qnap-letsencrypt version: $(git rev-parse --short HEAD)"
 echo "Using python path: $PYTHON"
 echo "Stopping Qthttpd hogging port 80.."
 


### PR DESCRIPTION
Just in case if you copy the script to a QNAP instead of doing a checkout.