### PR TITLE
Make sure to use entware xargs binary

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -45,7 +45,9 @@ echo "Stopping Qthttpd hogging port 80.."
 
 for PID in $(lsof -i tcp:80 -a -c python -t)
 do
-    echo "Killing old python process $PID hogging port 80" && kill $PID && sleep 1
+    echo "Killing old python process $PID hogging port 80" 
+    kill $PID 
+    sleep 1
 done
 
 mkdir -p tmp-webroot/.well-known/acme-challenge

--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -43,7 +43,7 @@ echo "Stopping Qthttpd hogging port 80.."
 
 /etc/init.d/Qthttpd.sh stop
 
-lsof -i tcp:80 -a -c python -t | xargs -r -I {} sh -c 'echo "Killing old python process {} hogging port 80" && kill {} && sleep 1'
+lsof -i tcp:80 -a -c python -t | /opt/bin/xargs -r -I {} sh -c 'echo "Killing old python process {} hogging port 80" && kill {} && sleep 1'
 
 mkdir -p tmp-webroot/.well-known/acme-challenge
 cd tmp-webroot

--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -43,14 +43,17 @@ echo "Stopping Qthttpd hogging port 80.."
 
 /etc/init.d/Qthttpd.sh stop
 
-lsof -i tcp:80 -a -c python -t | /opt/bin/xargs -r -I {} sh -c 'echo "Killing old python process {} hogging port 80" && kill {} && sleep 1'
+for PID in $(lsof -i tcp:80 -a -c python -t)
+do
+    echo "Killing old python process $PID hogging port 80" && kill $PID && sleep 1
+done
 
 mkdir -p tmp-webroot/.well-known/acme-challenge
 cd tmp-webroot
 "$PYTHON" ../HTTPServer.py &
-pid=$!
+PID=$!
 cd ..
-echo "Started python HTTP server with pid $pid"
+echo "Started python HTTP server with pid $PID"
 
 # Setup up-to-date certificates and bypass system certificate store
 export SSL_CERT_FILE=cacert.pem


### PR DESCRIPTION
Make sure to use the entware xargs binary located at `/opt/bin/xargs` instead of the busybox one `/usr/bin/xargs` which has only a reduced parameter set resulting in this error:
```
xargs: invalid option -- I
BusyBox v1.01 (2022.06.22-22:54+0000) multi-call binary

Usage: xargs [COMMAND] [OPTIONS] [ARGS...]

Executes COMMAND on every item given by standard input.

Options:
	-r	Do not run command for empty readed lines
	-x	Exit if the size is exceeded
	-0	Input filenames are terminated by a null character
	-t	Print the command line on stderr before executing it.
```