### PR TITLE
overwrite signed certificate only on ACME success

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -57,7 +57,9 @@ export SSL_CERT_FILE=cacert.pem
 export SSL_CERT_DIR=/dev/null
 
 "$PYTHON" acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/signed.crt.tmp
+if [ -f letsencrypt/signed.crt.tmp ] && [ -s letsencrypt/signed.crt.tmp ]; then
 mv letsencrypt/signed.crt.tmp letsencrypt/signed.crt
+fi
 echo "Downloading intermediate certificate..."
 wget --no-verbose --secure-protocol=TLSv1_2 -O - https://letsencrypt.org/certs/lets-encrypt-r3.pem > letsencrypt/intermediate.pem
 cat letsencrypt/signed.crt letsencrypt/intermediate.pem > letsencrypt/chained.pem


### PR DESCRIPTION
If the acme challenge fails, the signed.crt.tmp may be an empty file which may replace a still valid certificate file. This can be prevented by a file validity check before the old certificate gets replaced