### PR TITLE
read the intermediate name from the signed certificate

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -59,7 +59,9 @@ export SSL_CERT_DIR=/dev/null
 "$PYTHON" acme-tiny/acme_tiny.py --account-key letsencrypt/account.key --csr letsencrypt/domain.csr --acme-dir tmp-webroot/.well-known/acme-challenge > letsencrypt/signed.crt.tmp
 mv letsencrypt/signed.crt.tmp letsencrypt/signed.crt
 echo "Downloading intermediate certificate..."
-wget --no-verbose --secure-protocol=TLSv1_2 -O - https://letsencrypt.org/certs/lets-encrypt-r3.pem > letsencrypt/intermediate.pem
+
+INTERMEDIATE=$(openssl x509 -issuer -noout -in letsencrypt/signed.crt | awk -F= '{print $NF}')
+wget --no-verbose --secure-protocol=TLSv1_2 -O - https://letsencrypt.org/certs/lets-encrypt-$INTERMEDIATE.pem > letsencrypt/intermediate.pem
 cat letsencrypt/signed.crt letsencrypt/intermediate.pem > letsencrypt/chained.pem
 
 echo "Stopping stunnel and setting new stunnel certificates..."


### PR DESCRIPTION
Since letsencrypt sometimes changes their intermediate certificates, the name of the intermediate certificate should be read from the obtained signed certificate. With this change, the resulting name is currently `R3` and the correct intermediate is automatically downloaded and appended.