### PR TITLE
Improve Python3 test and find

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -42,7 +42,7 @@ done
 
 if [ -z "$PYTHON" ]; then
     echo "Error: Unable to find proper Python3 installation!"
-    echo "You may need to install Python3 from Entware."
+    echo "Try again after intalling Python3 from QNAP App Center (or from Entware if App Center package doesn't work)."
     exit 1
 fi
 

--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -23,16 +23,26 @@ cd "$SCRIPT_DIR"
 echo "Checking whether to renew certificate on $(date -R)"
 [ -s letsencrypt/signed.crt ] && openssl x509 -noout -in letsencrypt/signed.crt -checkend 2592000 && exit
 
-if python3 -c "import http.server" 2> /dev/null; then
-    PYTHON=python3
-elif "$(/sbin/getcfg QPython3 Install_Path -f /etc/config/qpkg.conf)/bin/python3" -c "import http.server" 2> /dev/null; then
-    PYTHON="$(/sbin/getcfg QPython3 Install_Path -f /etc/config/qpkg.conf)/bin/python3"
-elif "$(/sbin/getcfg Python3 Install_Path -f /etc/config/qpkg.conf)/python3/bin/python3" -c "import http.server" 2> /dev/null; then
-    PYTHON="$(/sbin/getcfg Python3 Install_Path -f /etc/config/qpkg.conf)/python3/bin/python3"
-elif "$(/sbin/getcfg Entware Install_Path -f /etc/config/qpkg.conf)/bin/python3" -c "import http.server" 2> /dev/null; then
-    PYTHON="$(/sbin/getcfg Entware Install_Path -f /etc/config/qpkg.conf)/bin/python3"
-else
-    echo "Error: You need to install the python 3.5 qpkg!"
+# test and find proper Python3 intallation
+python_paths=(
+    "python3"
+    "$(/sbin/getcfg QPython3 Install_Path -f /etc/config/qpkg.conf)/bin/python3"
+    "$(/sbin/getcfg Python3 Install_Path -f /etc/config/qpkg.conf)/python3/bin/python3"
+    "$(/sbin/getcfg Python3 Install_Path -f /etc/config/qpkg.conf)/opt/python3/bin/python3"
+    "$(/sbin/getcfg Entware Install_Path -f /etc/config/qpkg.conf)/bin/python3"
+)
+
+PYTHON=""
+for path in "${python_paths[@]}"; do
+    if $path -c "import http.server; import ssl" 2> /dev/null; then
+        PYTHON=$path
+        break
+    fi
+done
+
+if [ -z "$PYTHON" ]; then
+    echo "Error: Unable to find proper Python3 installation!"
+    echo "You may need to install Python3 from Entware."
     exit 1
 fi
 


### PR DESCRIPTION
- Refactoring
- Test ssl import (test if Python https:// support is broken)
- Add path candidate (for updated Python3 v3.12.6.1 from QNAP app center
  `$(/sbin/getcfg Python3 Install_Path -f /etc/config/qpkg.conf)/opt/python3/bin/python3`
- Change error message

Python's HTTPS support can be testd with `import ssl`. Below is example when HTTPS is broken.
```
$ . /etc/profile.d/python3.bash
$ python3
Python 3.10.4 (main, May  6 2022, 08:22:01) [GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ssl
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/share/CACHEDEV1_DATA/.qpkg/Python3/python3/lib/python3.10/ssl.py", line 98, in <module>
    import _ssl             # if we can't import it, let the error propagate
ImportError: libssl.so.1.1: cannot open shared object file: No such file or directory
>>> from urllib.request import urlopen
>>> urlopen("https://google.com")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/share/CACHEDEV1_DATA/.qpkg/Python3/python3/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/share/CACHEDEV1_DATA/.qpkg/Python3/python3/lib/python3.10/urllib/request.py", line 519, in open
    response = self._open(req, data)
  File "/share/CACHEDEV1_DATA/.qpkg/Python3/python3/lib/python3.10/urllib/request.py", line 541, in _open
    return self._call_chain(self.handle_open, 'unknown',
  File "/share/CACHEDEV1_DATA/.qpkg/Python3/python3/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/share/CACHEDEV1_DATA/.qpkg/Python3/python3/lib/python3.10/urllib/request.py", line 1419, in unknown_open
    raise URLError('unknown url type: %s' % type)
urllib.error.URLError: <urlopen error unknown url type: https>
>>> 
```

New Python3 v3.12.6.1 from QNAP app center has different path.
```
$ . /etc/profile.d/python3.bash
$ python3
Python 3.12.6 (main, Sep 26 2024, 03:12:39) [GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ssl
>>> exit()
$ which python3
/share/CACHEDEV1_DATA/.qpkg/Python3/opt/python3/bin/python3
$ /sbin/getcfg Python3 Install_Path -f /etc/config/qpkg.conf
/share/CACHEDEV1_DATA/.qpkg/Python3
```
